### PR TITLE
Allow Output.amount=0 when Output.asset_id is provided

### DIFF
--- a/payment-requests.mediawiki
+++ b/payment-requests.mediawiki
@@ -25,7 +25,7 @@ To enable merchants to accept payments in Open Assets units, we propose the foll
 # The <code>Output</code> message is extended with a field <code>optional bytes asset_id = 4001;</code> containing a 160-bit binary Asset ID (<code>RIPEMD-160(SHA-256(issuing script))</code>).
 # The <code>Output</code> message is extended with a field <code>optional uint64 asset_amount = 4002;</code> containing an amount of units.
 
-The optional field <code>output.amount</code> MUST NOT be specified (it's reserved for future use). The sender should include enough satoshis to exceed the dust limit (546 per simple output as of April 2015). This is similar to the responsibility of adding adequate mining fees to the transaction.
+If <code>output.asset_id</code> is specified, then field <code>output.amount</code> MUST NOT be specified or MUST equal zero (non-zero values are reserved for future use). The sender should include enough satoshis to exceed the dust limit (546 per simple output as of April 2015). This is similar to the responsibility of adding adequate mining fees to the transaction.
 
 If <code>output.amount</code> is specified, then <code>output.asset_id</code> and <code>output.asset_amount</code> MUST NOT be specified. This means that the output is a pure bitcoin output.
 


### PR DESCRIPTION
Looks like Golang's protobuf implementation serializes messages with default values for optional fields, so it's impossible to omit optional fields with explicit default values. This makes it impractical to require users to omit the `Output.amount` field if it's likely that their protobuf library includes it anyway. 

Allowing zero value does not seem to be pose a problem. To carry some assets an output must contain non-zero amount of satoshis anyway, so a zero value won't conflict with any meaningful value we would like to specify in the future.
